### PR TITLE
Document host endpoint explicitly

### DIFF
--- a/api.html
+++ b/api.html
@@ -11,6 +11,9 @@ forespørsler ikke nøl med å ta kontakt.</p>
 
 <h2>Oversikt</h2>
 
+<dt>Endpoint</dt>
+<dd>api.nasjonalturbase.no</dd>
+
 <div class="table-responsive">
   <table class="table table-bordered">
     <thead>


### PR DESCRIPTION
Although one might find this in the examples below, it would be useful
to explicitly document it in the overview.
